### PR TITLE
Update SerializerTest.java

### DIFF
--- a/src/test/java/io/deepreader/java/commons/util/SerializerTest.java
+++ b/src/test/java/io/deepreader/java/commons/util/SerializerTest.java
@@ -21,6 +21,9 @@ public class SerializerTest extends TestCase {
     }
 
     @Test
+    // This test fails. 
+    //Failed tests: testSerialize(io.deepreader.java.commons.util.SerializerTest):
+    //expected:<[0[.00000,1.00000,2.]00000]> but was:<[0[,00000,1,00000,2,]00000]>
     public void testSerialize() throws Exception {
         Double[] arr = new Double[] {0.0, 1.0, 2.0};
         assertEquals("[0.00000,1.00000,2.00000]", Serializer.serialize(arr));


### PR DESCRIPTION
tried fixing it by changing decimal format in Serializer to 
 DecimalFormat df = new DecimalFormat("0,00000");

Output of test in that case:
junit.framework.ComparisonFailure: 
Expected :[0.00000,1.00000,2.00000]
Actual   :[0.00000,0.00001,0.00002]junit.framework.ComparisonFailure: 
Expected :[0.00000,1.00000,2.00000]
Actual   :[0.00000,0.00001,0.00002]